### PR TITLE
[hotfix] flink-connector-hive artifactId with scala version

### DIFF
--- a/flink-connector-hive/pom.xml
+++ b/flink-connector-hive/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<version>3.0-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>flink-connector-hive</artifactId>
+	<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
 	<name>Flink : Connectors : Hive</name>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
The artifactId of this connector is `flink-connector-hive_${scala.binary.version}`.

checked in
1.  github.com/apache/flink repository (1.19.0-SNAPSHOT) and maven central  (1.18.0)
2. `github.com/apache/flink-connector-hive/flink-sql-connector-hive-x.x.x/pom.xml` (still with `scalar.binary.version`)