### PR TITLE
 [hotfix] Run end to end tests only if profile run-end-to-end-tests explicitely activated

### DIFF
--- a/flink-connector-hive-e2e-tests/pom.xml
+++ b/flink-connector-hive-e2e-tests/pom.xml
@@ -213,6 +213,16 @@ under the License.
 				<configuration>
 					<skip>${skip.e2e.tests}</skip>
 				</configuration>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>integration-tests</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Similar to other connectors