### PR TITLE
[hotfix] Add release tools as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tools/releasing/shared"]
+	path = tools/releasing/shared
+	url = https://github.com/apache/flink-connector-shared-utils
+	branch = release_utils


### PR DESCRIPTION
Required for RC creation as per https://cwiki.apache.org/confluence/display/FLINK/Creating+a+flink-connector+release
Similar to https://github.com/apache/flink-connector-kafka/commit/fae0538d94dbaff04c7c5b114f6b54e763c1f3bf