### PR TITLE
[#FLINK-33596] Fold expression before transfer function to RexNode

### DIFF
--- a/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
@@ -211,7 +211,7 @@ public class HiveParserRexNodeConverter {
 
     public RexNode convert(ExprNodeDesc expr) throws SemanticException {
         if (expr instanceof ExprNodeGenericFuncDesc) {
-            return convertGenericFunc((ExprNodeGenericFuncDesc) expr);
+            return convertGenericFunc((ExprNodeGenericFuncDesc) expr, cluster);
         } else if (expr instanceof ExprNodeConstantDesc) {
             return convertConstant((ExprNodeConstantDesc) expr, cluster);
         } else if (expr instanceof ExprNodeColumnDesc) {
@@ -518,12 +518,17 @@ public class HiveParserRexNodeConverter {
         return calciteLiteral;
     }
 
-    private RexNode convertGenericFunc(ExprNodeGenericFuncDesc func) throws SemanticException {
+    private RexNode convertGenericFunc(ExprNodeGenericFuncDesc func, RelOptCluster cluster) throws SemanticException {
         ExprNodeDesc tmpExprNode;
         RexNode tmpRN;
 
         List<RexNode> childRexNodeLst = new ArrayList<>();
         List<RelDataType> argTypes = new ArrayList<>();
+
+        ExprNodeDesc afterFoldDesc = ConstantPropagateProcFactory.foldExpr(func);
+        if (afterFoldDesc instanceof ExprNodeConstantDesc) {
+            return convertConstant((ExprNodeConstantDesc) afterFoldDesc, cluster);
+        }
 
         // TODO: 1) Expand to other functions as needed 2) What about types other than primitive.
         TypeInfo tgtDT = null;

--- a/flink-connector-hive/src/test/resources/query-test/group_by.q
+++ b/flink-connector-hive/src/test/resources/query-test/group_by.q
@@ -31,3 +31,7 @@ select dep,count(1) from employee where salary<5000 and age>=38 and dep='Sales' 
 select x,null as n from foo group by x,'a',null;
 
 [+I[1, null], +I[2, null], +I[3, null], +I[4, null], +I[5, null]]
+
+select dep, sum(salary) from employee group by dep, UNIX_TIMESTAMP();
+
+[+I[Management, 12900], +I[Production, 18600], +I[Sales, 8400], +I[Service, 4100]]


### PR DESCRIPTION
## What is the purpose of the change
Fold expression before transfer function to RexNode.
Hive will fold expression in optimization stage. 
But flink-hive-parser use flink optimization.
And flink can't know some hive function can be constant value.

Some hive code reference:

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRexExecutorImpl.java#L62

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java#L1776

https://github.com/apache/hive/blob/rel/release-2.3.9/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java#L1069

## Brief change log
Try to transfer to constant before function transfer to rexNode.

## Verifying this change
This change is verified by added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

