### PR TITLE
[FLINK-36887][hive] Bumping to 1.20.0

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.18-SNAPSHOT, 1.19-SNAPSHOT ]
+        flink: [ 1.20-SNAPSHOT ]
         jdk: [ 8, 11 ]
         # empty means test against hive2
         mvn_profile: [ "", hive3 ]
@@ -34,10 +34,7 @@ jobs:
             mvn_profile: hive3
         include:
           - jdk: 11
-            flink: 1.18-SNAPSHOT
-            mvn_profile: "hive3,skipE2ETests"
-          - jdk: 11
-            flink: 1.19-SNAPSHOT
+            flink: 1.20-SNAPSHOT
             mvn_profile: "hive3,skipE2ETests"
 
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [ 1.18.0, 1.18-SNAPSHOT, 1.19-SNAPSHOT ]
+        flink: [ 1.20.0, 1.20-SNAPSHOT ]
         jdk: [ 8, 11 ]
         # empty means test against hive2
         mvn_profile: [ "", hive3 ]
@@ -35,13 +35,10 @@ jobs:
             mvn_profile: hive3
         include:
           - jdk: 11
-            flink: 1.18.0
+            flink: 1.20.0
             mvn_profile: "hive3,skipE2ETests"
           - jdk: 11
-            flink: 1.18-SNAPSHOT
-            mvn_profile: "hive3,skipE2ETests"
-          - jdk: 11
-            flink: 1.19-SNAPSHOT
+            flink: 1.20-SNAPSHOT
             mvn_profile: "hive3,skipE2ETests"
 
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/flink-connector-hive-e2e-tests/pom.xml
+++ b/flink-connector-hive-e2e-tests/pom.xml
@@ -85,7 +85,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-hive-${hive.version}_${scala.binary.version}</artifactId>
-			<version>${flink.version}</version>
+			<version>${version}</version>
 		</dependency>
 
 		<!-- hadoop dependencies for end-to-end test -->
@@ -183,7 +183,7 @@ under the License.
 									<artifactId>
 										flink-sql-connector-hive-${hive.version}_${scala.binary.version}
 									</artifactId>
-									<version>${flink.version}</version>
+									<version>${version}</version>
 									<destFileName>
 										sql-hive-${hive.version}_${scala.binary.version}.jar
 									</destFileName>

--- a/flink-connector-hive/pom.xml
+++ b/flink-connector-hive/pom.xml
@@ -1160,6 +1160,14 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-datagen</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- HiveServer2 Endpoint -->
 
 		<dependency>

--- a/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/ThriftObjectConversions.java
@@ -108,7 +108,7 @@ public class ThriftObjectConversions {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final RowDataToJsonConverters TO_JSON_CONVERTERS =
             new RowDataToJsonConverters(
-                    TimestampFormat.SQL, JsonFormatOptions.MapNullKeyMode.LITERAL, "null");
+                    TimestampFormat.SQL, JsonFormatOptions.MapNullKeyMode.LITERAL, "null", false);
     private static final Map<String, TableKind> TABLE_TYPE_MAPPINGS = buildTableTypeMapping();
 
     // --------------------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.18.0</flink.version>
+        <flink.version>1.20.0</flink.version>
 
         <assertj.version>3.24.2</assertj.version>
         <!--


### PR DESCRIPTION
Refer to the discussion in https://lists.apache.org/thread/v44y2yh4b5wyp1lqrxgxc8qh680wpgfr, bumping to 1.20 can help us  to better prepare next release.

A following pr to cherry-pick relevant changes in Flink main repo is necessary.