### PR TITLE
[FLINK-36594][hive]HiveCatalog should set HiveConf.hiveSiteLocation back

### DIFF
--- a/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -254,11 +254,14 @@ public class HiveCatalog extends AbstractCatalog {
         if (hadoopConf == null) {
             hadoopConf = new Configuration();
         }
-        // ignore all the static conf file URLs that HiveConf may have set
+        // ignore all the static conf file URLs that HiveConf may have
+        URL originalHiveSiteURL = HiveConf.getHiveSiteLocation();
         HiveConf.setHiveSiteLocation(null);
         HiveConf.setLoadMetastoreConfig(false);
         HiveConf.setLoadHiveServer2Config(false);
         HiveConf hiveConf = new HiveConf(hadoopConf, HiveConf.class);
+        // set it back if there was a hive-site.xml to keep HiveConf behaviour as expected
+        HiveConf.setHiveSiteLocation(originalHiveSiteURL);
 
         LOG.info("Setting hive conf dir as {}", hiveConfDir);
 

--- a/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -254,14 +254,19 @@ public class HiveCatalog extends AbstractCatalog {
         if (hadoopConf == null) {
             hadoopConf = new Configuration();
         }
-        // ignore all the static conf file URLs that HiveConf may have
+        // ignore all the static conf file URLs and load flags that HiveConf may have
+        // backup original static settings so we can restore them after creating new HiveConf
         URL originalHiveSiteURL = HiveConf.getHiveSiteLocation();
+        boolean originalLoadMetastoreConfig = HiveConf.isLoadMetastoreConfig();
+        boolean originalLoadHiveServer2Config = HiveConf.isLoadHiveServer2Config();
         HiveConf.setHiveSiteLocation(null);
         HiveConf.setLoadMetastoreConfig(false);
         HiveConf.setLoadHiveServer2Config(false);
         HiveConf hiveConf = new HiveConf(hadoopConf, HiveConf.class);
-        // set it back if there was a hive-site.xml to keep HiveConf behaviour as expected
+        // restore previous static settings to keep HiveConf behaviour as expected
         HiveConf.setHiveSiteLocation(originalHiveSiteURL);
+        HiveConf.setLoadMetastoreConfig(originalLoadMetastoreConfig);
+        HiveConf.setLoadHiveServer2Config(originalLoadHiveServer2Config);
 
         LOG.info("Setting hive conf dir as {}", hiveConfDir);
 

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -44,6 +44,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -338,6 +339,35 @@ public class HiveCatalogTest {
                         .getPath();
         hiveConf = HiveCatalog.createHiveConf(hiveConfDir, null);
         assertThat(hiveConf.get("common-key")).isNull();
+    }
+
+    @Test
+    public void testCreateHiveConfRestoresStaticSettings() throws Exception {
+        // backup originals
+        URL originalHiveSiteURL = HiveConf.getHiveSiteLocation();
+        boolean originalLoadMetastoreConfig = HiveConf.isLoadMetastoreConfig();
+        boolean originalLoadHiveServer2Config = HiveConf.isLoadHiveServer2Config();
+
+        try {
+            // set distinct values
+            URL testUrl = new URL("file:/tmp/test-hive-site.xml");
+            HiveConf.setHiveSiteLocation(testUrl);
+            HiveConf.setLoadMetastoreConfig(true);
+            HiveConf.setLoadHiveServer2Config(true);
+
+            // call the method under test
+            HiveConf hiveConf = HiveCatalog.createHiveConf(null, null);
+
+            // static settings should be restored to the values we set
+            assertThat(HiveConf.getHiveSiteLocation()).isEqualTo(testUrl);
+            assertThat(HiveConf.isLoadMetastoreConfig()).isTrue();
+            assertThat(HiveConf.isLoadHiveServer2Config()).isTrue();
+        } finally {
+            // restore originals to avoid affecting other tests
+            HiveConf.setHiveSiteLocation(originalHiveSiteURL);
+            HiveConf.setLoadMetastoreConfig(originalLoadMetastoreConfig);
+            HiveConf.setLoadHiveServer2Config(originalLoadHiveServer2Config);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
Using HiveCatalog will cause another hive program lost the hive-site.xml from HiveConf

This change will set HiveConf.hiveSiteLocation back.

This will reduce the complexity caused by the loading order of static configuration files in HiveConf that other big data components depend on.

## Brief change log
Visit JIRA ticket to for details.

Originally created from flink repo: https://github.com/apache/flink/pull/25568

