### PR TITLE
[FLINK-29432][hive] Replace GenericUDFNvl with GenericUDFCoalesce

### DIFF
--- a/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
@@ -73,8 +73,8 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.udf.SettableUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBaseCompare;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCoalesce;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInternalInterval;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNvl;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPDivide;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
@@ -1215,10 +1215,10 @@ public class HiveParserTypeCheckProcFactory {
                     }
                     desc = ExprNodeGenericFuncDesc.newInstance(genericUDF, funcText, children);
                 } else if (ctx.isFoldExpr() && canConvertIntoNvl(genericUDF, children)) {
-                    // Rewrite CASE into NVL
+                    // Rewrite CASE into COALESCE
                     desc =
                             ExprNodeGenericFuncDesc.newInstance(
-                                    new GenericUDFNvl(),
+                                    new GenericUDFCoalesce(),
                                     new ArrayList<>(
                                             Arrays.asList(
                                                     children.get(0),


### PR DESCRIPTION
## What is the purpose of the change

Replace `GenericUDFNvl` with `GenericUDFCoalesce` in the CASE-to-NVL expression folding optimization.

`GenericUDFNvl` was removed in Hive 4 (HIVE-20961). `NVL(a, b)` is semantically identical to `COALESCE(a, b)` — both return the first non-null argument. `GenericUDFCoalesce` is available in all supported Hive versions (2.3+).

*JIRA: [FLINK-29432](https://issues.apache.org/jira/browse/FLINK-29432)*

## Brief change log

- Replace `GenericUDFNvl` with `GenericUDFCoalesce` in `HiveParserTypeCheckProcFactory` (1 file, 3 lines changed)

## Does this pull request potentially affect one of the following parts?

- Dependencies: **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**