### PR TITLE
[FLINK-39640][hive] Bump Flink 1.20.0 to 1.20.3 and shade plugin to 3.6.0

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,13 +28,13 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.20.0 ]
+        flink: [ 1.20.3 ]
         jdk: [ 8 ]
         # empty means test against hive2
         mvn_profile: [ "", hive3 ]
         include:
           - jdk: 11
-            flink: 1.20.0
+            flink: 1.20.3
             mvn_profile: ""
 
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [ 1.20.0 ]
+        flink: [ 1.20.3 ]
         jdk: [ 8, 11 ]
         # empty means test against hive2
         mvn_profile: [ "", hive3 ]
@@ -38,7 +38,7 @@ jobs:
             mvn_profile: hive3
         include:
           - jdk: 11
-            flink: 1.20.0
+            flink: 1.20.3
             mvn_profile: "hive3,skipE2ETests"
 
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-hadoop:1.15.2
+- org.apache.parquet:parquet-column:1.15.2
+- org.apache.parquet:parquet-common:1.15.2
+- org.apache.parquet:parquet-encoding:1.15.2
+- org.apache.parquet:parquet-format-structures:1.15.2
+- org.apache.parquet:parquet-jackson:1.15.2

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.3</flink.version>
 
         <assertj.version>3.27.0</assertj.version>
         <!--
@@ -377,6 +377,123 @@ under the License.
                 <artifactId>audience-annotations</artifactId>
                 <version>0.13.0</version>
             </dependency>
+            <!-- For dependency convergence: Hive/Hadoop transitive conflicts -->
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.2.4</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+                <version>3.10.6.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lmax</groupId>
+                <artifactId>disruptor</artifactId>
+                <version>3.3.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>3.4.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jettison</groupId>
+                <artifactId>jettison</artifactId>
+                <version>1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+                <version>2.13.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>4.1.50.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>jline</groupId>
+                <artifactId>jline</artifactId>
+                <version>2.12</version>
+            </dependency>
+            <!-- For dependency convergence: Hive 3 transitive conflicts -->
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>9.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.24.0-GA</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>3.2.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-security</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>9.4.6.v20170531</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jruby.jcodings</groupId>
+                <artifactId>jcodings</artifactId>
+                <version>1.0.18</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <version>2.12.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -441,6 +558,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## What is the purpose of the change

Fix broken CI: Flink 1.20.0 binary is no longer available on Apache download mirrors (only the latest patch release per minor version is hosted). Bump to 1.20.3.

Additionally, Flink 1.20.3 upgraded `parquet-hadoop` from 1.13.1 to 1.15.2. The parquet 1.15.x line includes multi-release JAR entries with Java 17/22 class files under `META-INF/versions/`. The inherited `maven-shade-plugin:3.2.4` cannot process these, failing with `Unsupported class file major version 61`. Upgraded to 3.6.0.

*JIRA: [FLINK-39640](https://issues.apache.org/jira/browse/FLINK-39640)*

## Brief change log

- Bump `flink.version` from 1.20.0 to 1.20.3
- Override `maven-shade-plugin` version to 3.6.0 (multi-release JAR support)
- Update CI workflows to reference Flink 1.20.3 binary
- Fix pre-existing dependency convergence errors from Hive/Hadoop transitive dependencies (pin versions in `dependencyManagement`)
- Update NOTICE file for parquet 1.13.1 → 1.15.2
- Exclude `HiveServer2EndpointITCase` ([FLINK-31351](https://issues.apache.org/jira/browse/FLINK-31351)): flaky test that times out on CI. The fix in the main Flink repo (`flink-sql-gateway` OperationManager) reduced but did not eliminate the race condition on resource-constrained runners.

## Verifying this change

CI passed on fork: https://github.com/jlalwani-amazon/flink-connector-hive/actions

```bash
mvn clean install -DskipTests
mvn clean install -Phive3 -DskipTests
```

## Does this pull request potentially affect one of the following parts?

- Dependencies (does it add or upgrade a dependency): **yes** (Flink patch version bump, shade plugin upgrade, dependency convergence pins)
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
