### PR TITLE
[FLINK-39657][hive] Migrate CatalogTable.of() to CatalogTable.newBuilder()

### DIFF
--- a/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -796,7 +796,12 @@ public class HiveCatalog extends AbstractCatalog {
                     hiveTable.getViewExpandedText(),
                     properties);
         } else {
-            return CatalogTable.of(schema, comment, partitionKeys, properties);
+            return CatalogTable.newBuilder()
+                    .schema(schema)
+                    .comment(comment)
+                    .partitionKeys(partitionKeys)
+                    .options(properties)
+                    .build();
         }
     }
 

--- a/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
@@ -436,11 +436,12 @@ public class HiveParserDMLHelper {
             ResolvedSchema resolvedSchema, Map<String, String> props) {
         Schema schema = Schema.newBuilder().fromResolvedSchema(resolvedSchema).build();
         CatalogTable catalogTable =
-                CatalogTable.of(
-                        schema,
-                        "a dummy table for the case of insert overwrite directory ",
-                        Collections.emptyList(),
-                        props);
+                CatalogTable.newBuilder()
+                        .schema(schema)
+                        .comment("a dummy table for the case of insert overwrite directory ")
+                        .partitionKeys(Collections.emptyList())
+                        .options(props)
+                        .build();
         ResolvedCatalogTable resolvedCatalogTable =
                 new ResolvedCatalogTable(catalogTable, resolvedSchema);
         String currentCatalog = catalogRegistry.getCurrentCatalog();

--- a/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
@@ -662,11 +662,15 @@ public class HiveParserSemanticAnalyzer {
             ResolvedSchema resolvedSchema = ResolvedSchema.physical(fieldsName, fieldsDataType);
             ResolvedCatalogTable tempTable =
                     new ResolvedCatalogTable(
-                            CatalogTable.of(
-                                    Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                    "values temp table",
-                                    new ArrayList<>(),
-                                    Collections.emptyMap()),
+                            CatalogTable.newBuilder()
+                                    .schema(
+                                            Schema.newBuilder()
+                                                    .fromResolvedSchema(resolvedSchema)
+                                                    .build())
+                                    .comment("values temp table")
+                                    .partitionKeys(new ArrayList<>())
+                                    .options(Collections.emptyMap())
+                                    .build(),
                             resolvedSchema);
             // remember the data for this table
             qb.getValuesTableToData().put(tableName, Tuple2.of(tempTable, valuesData));

--- a/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
@@ -1065,11 +1065,15 @@ public class HiveParserDDLSemanticAnalyzer {
                                 cols, partCols, Collections.emptySet(), null);
                 ResolvedCatalogTable destTable =
                         new ResolvedCatalogTable(
-                                CatalogTable.of(
-                                        Schema.newBuilder().fromResolvedSchema(schema).build(),
-                                        comment,
-                                        HiveCatalog.getFieldNames(partCols),
-                                        tblProps),
+                                CatalogTable.newBuilder()
+                                        .schema(
+                                                Schema.newBuilder()
+                                                        .fromResolvedSchema(schema)
+                                                        .build())
+                                        .comment(comment)
+                                        .partitionKeys(HiveCatalog.getFieldNames(partCols))
+                                        .options(tblProps)
+                                        .build(),
                                 schema);
 
                 Tuple4<ObjectIdentifier, QueryOperation, Map<String, String>, Boolean>
@@ -1195,7 +1199,12 @@ public class HiveParserDDLSemanticAnalyzer {
         Schema schema = HiveTableUtil.createSchema(cols, partCols, notNullColSet, uniqueConstraint);
         return new CreateTableOperation(
                 identifier,
-                CatalogTable.of(schema, comment, HiveCatalog.getFieldNames(partCols), props),
+                CatalogTable.newBuilder()
+                        .schema(schema)
+                        .comment(comment)
+                        .partitionKeys(HiveCatalog.getFieldNames(partCols))
+                        .options(props)
+                        .build(),
                 ifNotExists,
                 isTemporary);
     }
@@ -1984,11 +1993,12 @@ public class HiveParserDDLSemanticAnalyzer {
                 tableIdentifier,
                 tableChanges,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(newSchema).build(),
-                                oldTable.getComment(),
-                                oldTable.getPartitionKeys(),
-                                props),
+                        CatalogTable.newBuilder()
+                                .schema(Schema.newBuilder().fromResolvedSchema(newSchema).build())
+                                .comment(oldTable.getComment())
+                                .partitionKeys(oldTable.getPartitionKeys())
+                                .options(props)
+                                .build(),
                         newSchema),
                 false);
     }
@@ -2055,11 +2065,12 @@ public class HiveParserDDLSemanticAnalyzer {
         return new AlterTableSchemaOperation(
                 tableIdentifier,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(newSchema).build(),
-                                oldTable.getComment(),
-                                oldTable.getPartitionKeys(),
-                                props),
+                        CatalogTable.newBuilder()
+                                .schema(Schema.newBuilder().fromResolvedSchema(newSchema).build())
+                                .comment(oldTable.getComment())
+                                .partitionKeys(oldTable.getPartitionKeys())
+                                .options(props)
+                                .build(),
                         newSchema),
                 false);
     }

--- a/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDeserializeExceptionTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDeserializeExceptionTest.java
@@ -74,11 +74,12 @@ public class HiveDeserializeExceptionTest {
                         new Properties(),
                         new JobConf(),
                         new ResolvedCatalogTable(
-                                CatalogTable.of(
-                                        Schema.newBuilder().build(),
-                                        null,
-                                        new ArrayList<>(),
-                                        Collections.emptyMap()),
+                                CatalogTable.newBuilder()
+                                        .schema(Schema.newBuilder().build())
+                                        .comment(null)
+                                        .partitionKeys(new ArrayList<>())
+                                        .options(Collections.emptyMap())
+                                        .build(),
                                 ResolvedSchema.of()),
                         HiveShimLoader.getHiveVersion(),
                         RowType.of(DataTypes.INT().getLogicalType()),
@@ -87,11 +88,15 @@ public class HiveDeserializeExceptionTest {
         ResolvedSchema resolvedSchema = ResolvedSchema.of(Column.physical("i", DataTypes.INT()));
         ResolvedCatalogTable resolvedCatalogTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                null,
-                                Collections.emptyList(),
-                                Collections.emptyMap()),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(Collections.emptyList())
+                                .options(Collections.emptyMap())
+                                .build(),
                         resolvedSchema);
         HiveSourceBuilder builder =
                 new HiveSourceBuilder(

--- a/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceITCase.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceITCase.java
@@ -79,11 +79,15 @@ public class HiveSourceITCase {
         hiveCatalog.createTable(
                 tablePath,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                null,
-                                new ArrayList<>(),
-                                tableOptions),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(new ArrayList<>())
+                                .options(tableOptions)
+                                .build(),
                         resolvedSchema),
                 false);
         HiveTestUtils.createTextTableInserter(
@@ -126,11 +130,15 @@ public class HiveSourceITCase {
         hiveCatalog.createTable(
                 tablePath,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                null,
-                                Collections.singletonList("p"),
-                                tableOptions),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(Collections.singletonList("p"))
+                                .options(tableOptions)
+                                .build(),
                         resolvedSchema),
                 false);
         HiveTestUtils.createTextTableInserter(

--- a/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceTest.java
@@ -224,13 +224,15 @@ class HiveSourceTest {
         hiveCatalog.createTable(
                 tablePath,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder()
-                                        .fromResolvedSchema(partitionTableRSchema)
-                                        .build(),
-                                null,
-                                isPartitioned ? keys : Collections.emptyList(),
-                                tableOptions),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(partitionTableRSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(isPartitioned ? keys : Collections.emptyList())
+                                .options(tableOptions)
+                                .build(),
                         partitionTableRSchema),
                 false);
 

--- a/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -88,7 +88,12 @@ class HiveTableFactoryTest {
                 Collections.singletonMap(FactoryUtil.CONNECTOR.key(), "COLLECTION");
         final CatalogTable table =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, "csv table", new ArrayList<>(), options),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("csv table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(options)
+                                .build(),
                         resolvedSchema);
         catalog.createTable(new ObjectPath("mydb", "mytable"), table, true);
 
@@ -129,11 +134,12 @@ class HiveTableFactoryTest {
                 Collections.singletonMap(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
         final CatalogTable table =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(schema).build(),
-                                "hive table",
-                                new ArrayList<>(),
-                                options),
+                        CatalogTable.newBuilder()
+                                .schema(Schema.newBuilder().fromResolvedSchema(schema).build())
+                                .comment("hive table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(options)
+                                .build(),
                         schema);
         catalog.createTable(new ObjectPath("mydb", "mytable"), table, true);
 

--- a/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherTest.java
@@ -66,7 +66,13 @@ public class HivePartitionFetcherTest {
         List<String> partitionKeys = Collections.singletonList("date");
         Map<String, String> options = new HashMap<>();
         options.put("connector", "hive");
-        CatalogTable catalogTable = CatalogTable.of(schema, null, partitionKeys, options);
+        CatalogTable catalogTable =
+                CatalogTable.newBuilder()
+                        .schema(schema)
+                        .comment(null)
+                        .partitionKeys(partitionKeys)
+                        .options(options)
+                        .build();
         ResolvedCatalogTable resolvedCatalogTable =
                 new ResolvedCatalogTable(
                         catalogTable, ResolvedSchema.physical(fieldNames, fieldTypes));

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -205,16 +205,18 @@ public class HiveCatalogDataTypeTest {
         Schema schema = Schema.newBuilder().fromResolvedSchema(resolvedSchema).build();
 
         return new ResolvedCatalogTable(
-                CatalogTable.of(
-                        schema,
-                        "",
-                        new ArrayList<>(),
-                        new HashMap<String, String>() {
-                            {
-                                put("is_streaming", "false");
-                                put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
-                            }
-                        }),
+                CatalogTable.newBuilder()
+                        .schema(schema)
+                        .comment("")
+                        .partitionKeys(new ArrayList<>())
+                        .options(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("is_streaming", "false");
+                                        put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
+                                    }
+                                })
+                        .build(),
                 resolvedSchema);
     }
 

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -82,8 +82,12 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
         final Schema schema = Schema.newBuilder().fromResolvedSchema(resolvedSchema).build();
 
         final CatalogTable origin =
-                CatalogTable.of(
-                        schema, TEST_COMMENT, Collections.emptyList(), getBatchTableProperties());
+                CatalogTable.newBuilder()
+                        .schema(schema)
+                        .comment(TEST_COMMENT)
+                        .partitionKeys(Collections.emptyList())
+                        .options(getBatchTableProperties())
+                        .build();
 
         ObjectPath tablePath = new ObjectPath(db1, "generic_table");
         try {
@@ -381,11 +385,15 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
                         null);
         CatalogTable catalogTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                null,
-                                new ArrayList<>(),
-                                Collections.emptyMap()),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(new ArrayList<>())
+                                .options(Collections.emptyMap())
+                                .build(),
                         resolvedSchema);
         catalog.createTable(path1, catalogTable, false);
         CatalogTable retrievedTable = (CatalogTable) catalog.getTable(path1);

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -185,11 +185,15 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
         ResolvedSchema resolvedSchema = new ResolvedSchema(columns, new ArrayList<>(), null);
         CatalogTable catalogTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                TEST_COMMENT,
-                                new ArrayList<>(),
-                                getBatchTableProperties()),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(TEST_COMMENT)
+                                .partitionKeys(new ArrayList<>())
+                                .options(getBatchTableProperties())
+                                .build(),
                         resolvedSchema);
         catalog.createTable(path1, catalogTable, false);
         Map<String, CatalogColumnStatisticsDataBase> columnStatisticsDataBaseMap = new HashMap<>();
@@ -274,11 +278,15 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
         hiveCatalog.createTable(
                 path1,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                null,
-                                new ArrayList<>(),
-                                getBatchTableProperties()),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment(null)
+                                .partitionKeys(new ArrayList<>())
+                                .options(getBatchTableProperties())
+                                .build(),
                         resolvedSchema),
                 false);
         CatalogTable catalogTable = (CatalogTable) hiveCatalog.getTable(path1);
@@ -339,11 +347,15 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
                         null);
         CatalogTable resolveCatalogTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                "",
-                                new ArrayList<>(),
-                                properties),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment("")
+                                .partitionKeys(new ArrayList<>())
+                                .options(properties)
+                                .build(),
                         resolvedSchema);
         catalog.createTable(path1, resolveCatalogTable, false);
 
@@ -614,11 +626,12 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
                         null);
         catalog.createDatabase(db1, createDb(), false);
         final CatalogTable origin =
-                CatalogTable.of(
-                        Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                        TEST_COMMENT,
-                        createPartitionKeys(),
-                        getBatchTableProperties());
+                CatalogTable.newBuilder()
+                        .schema(Schema.newBuilder().fromResolvedSchema(resolvedSchema).build())
+                        .comment(TEST_COMMENT)
+                        .partitionKeys(createPartitionKeys())
+                        .options(getBatchTableProperties())
+                        .build();
         CatalogTable catalogTable = new ResolvedCatalogTable(origin, resolvedSchema);
 
         catalog.createTable(path1, catalogTable, false);

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -172,11 +172,15 @@ public class HiveCatalogITCase {
 
         CatalogTable source =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                "Comment.",
-                                new ArrayList<>(),
-                                sourceOptions),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment("Comment.")
+                                .partitionKeys(new ArrayList<>())
+                                .options(sourceOptions)
+                                .build(),
                         resolvedSchema);
 
         Path p = Paths.get(tempFolder.newFolder().getAbsolutePath(), "test.csv");
@@ -188,11 +192,15 @@ public class HiveCatalogITCase {
 
         CatalogTable sink =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().fromResolvedSchema(resolvedSchema).build(),
-                                "Comment.",
-                                new ArrayList<>(),
-                                sinkOptions),
+                        CatalogTable.newBuilder()
+                                .schema(
+                                        Schema.newBuilder()
+                                                .fromResolvedSchema(resolvedSchema)
+                                                .build())
+                                .comment("Comment.")
+                                .partitionKeys(new ArrayList<>())
+                                .options(sinkOptions)
+                                .build(),
                         resolvedSchema);
 
         hiveCatalog.createTable(

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -92,11 +92,12 @@ public class HiveCatalogTest {
     public void testCreateAndGetFlinkManagedTable() throws Exception {
         CatalogTable table =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema,
-                                "Flink managed table",
-                                new ArrayList<>(),
-                                Collections.emptyMap()),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(Collections.emptyMap())
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, table, false);
         Table hiveTable = hiveCatalog.getHiveTable(tablePath);
@@ -115,11 +116,12 @@ public class HiveCatalogTest {
                         FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema,
-                                "Flink non-managed table",
-                                new ArrayList<>(),
-                                originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink non-managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
@@ -127,8 +129,12 @@ public class HiveCatalogTest {
 
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink managed table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -144,11 +150,12 @@ public class HiveCatalogTest {
                         FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema,
-                                "Flink non-managed table",
-                                new ArrayList<>(),
-                                originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink non-managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
@@ -156,7 +163,12 @@ public class HiveCatalogTest {
         newOptions.put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, "Hive table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Hive table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -170,8 +182,12 @@ public class HiveCatalogTest {
         Map<String, String> originOptions = Collections.emptyMap();
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink managed table", new ArrayList<>(), originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
@@ -180,8 +196,12 @@ public class HiveCatalogTest {
                         FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink non-managed table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink non-managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -195,8 +215,12 @@ public class HiveCatalogTest {
         Map<String, String> originOptions = Collections.emptyMap();
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink managed table", new ArrayList<>(), originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
@@ -204,7 +228,12 @@ public class HiveCatalogTest {
         newOptions.put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, "Hive table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Hive table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -219,15 +248,24 @@ public class HiveCatalogTest {
         originOptions.put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, "Hive table", new ArrayList<>(), originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Hive table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
         Map<String, String> newOptions = Collections.emptyMap();
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink managed table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -242,7 +280,12 @@ public class HiveCatalogTest {
         originOptions.put(FactoryUtil.CONNECTOR.key(), IDENTIFIER);
         CatalogTable originTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, "Hive table", new ArrayList<>(), originOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Hive table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(originOptions)
+                                .build(),
                         resolvedSchema);
         hiveCatalog.createTable(tablePath, originTable, false);
 
@@ -251,8 +294,12 @@ public class HiveCatalogTest {
                         FactoryUtil.CONNECTOR.key(), DataGenTableSourceFactory.IDENTIFIER);
         CatalogTable newTable =
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                schema, "Flink managed table", new ArrayList<>(), newOptions),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment("Flink managed table")
+                                .partitionKeys(new ArrayList<>())
+                                .options(newOptions)
+                                .build(),
                         resolvedSchema);
         assertThatThrownBy(() -> hiveCatalog.alterTable(tablePath, newTable, false))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -267,11 +314,12 @@ public class HiveCatalogTest {
                 HiveTableUtil.instantiateHiveTable(
                         new ObjectPath("test", "test"),
                         new ResolvedCatalogTable(
-                                CatalogTable.of(
-                                        schema,
-                                        null,
-                                        new ArrayList<>(),
-                                        getLegacyFileSystemConnectorOptions("/test_path")),
+                                CatalogTable.newBuilder()
+                                        .schema(schema)
+                                        .comment(null)
+                                        .partitionKeys(new ArrayList<>())
+                                        .options(getLegacyFileSystemConnectorOptions("/test_path"))
+                                        .build(),
                                 resolvedSchema),
                         HiveTestUtils.createHiveConf(),
                         false);
@@ -291,7 +339,12 @@ public class HiveCatalogTest {
                 HiveTableUtil.instantiateHiveTable(
                         new ObjectPath("test", "test"),
                         new ResolvedCatalogTable(
-                                CatalogTable.of(schema, null, new ArrayList<>(), options),
+                                CatalogTable.newBuilder()
+                                        .schema(schema)
+                                        .comment(null)
+                                        .partitionKeys(new ArrayList<>())
+                                        .options(options)
+                                        .build(),
                                 resolvedSchema),
                         HiveTestUtils.createHiveConf(),
                         false);
@@ -315,7 +368,13 @@ public class HiveCatalogTest {
         hiveCatalog.createTable(
                 hiveObjectPath,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(schema, null, new ArrayList<>(), options), resolvedSchema),
+                        CatalogTable.newBuilder()
+                                .schema(schema)
+                                .comment(null)
+                                .partitionKeys(new ArrayList<>())
+                                .options(options)
+                                .build(),
+                        resolvedSchema),
                 false);
 
         CatalogBaseTable hiveTable = hiveCatalog.getTable(hiveObjectPath);
@@ -352,8 +411,12 @@ public class HiveCatalogTest {
         hiveCatalog.createTable(
                 hiveObjectPath,
                 new ResolvedCatalogTable(
-                        CatalogTable.of(
-                                Schema.newBuilder().build(), null, new ArrayList<>(), properties),
+                        CatalogTable.newBuilder()
+                                .schema(Schema.newBuilder().build())
+                                .comment(null)
+                                .partitionKeys(new ArrayList<>())
+                                .options(properties)
+                                .build(),
                         ResolvedSchema.of()),
                 false);
 

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
@@ -110,11 +110,12 @@ public class HiveCatalogUdfITCase extends AbstractTestBaseJUnit4 {
         sourceOptions.put("format.type", "csv");
 
         CatalogTable unresolved =
-                CatalogTable.of(
-                        Schema.newBuilder().fromResolvedSchema(schema).build(),
-                        "Comment.",
-                        new ArrayList<>(),
-                        sourceOptions);
+                CatalogTable.newBuilder()
+                        .schema(Schema.newBuilder().fromResolvedSchema(schema).build())
+                        .comment("Comment.")
+                        .partitionKeys(new ArrayList<>())
+                        .options(sourceOptions)
+                        .build();
         ResolvedCatalogTable source = new ResolvedCatalogTable(unresolved, schema);
 
         hiveCatalog.createTable(
@@ -188,11 +189,12 @@ public class HiveCatalogUdfITCase extends AbstractTestBaseJUnit4 {
             sinkOptions.put("format.type", "csv");
 
             CatalogTable unresolved =
-                    CatalogTable.of(
-                            Schema.newBuilder().fromResolvedSchema(sinkSchema).build(),
-                            "Comment.",
-                            new ArrayList<>(),
-                            sinkOptions);
+                    CatalogTable.newBuilder()
+                            .schema(Schema.newBuilder().fromResolvedSchema(sinkSchema).build())
+                            .comment("Comment.")
+                            .partitionKeys(new ArrayList<>())
+                            .options(sinkOptions)
+                            .build();
             final ResolvedCatalogTable sink = new ResolvedCatalogTable(unresolved, sinkSchema);
 
             hiveCatalog.createTable(


### PR DESCRIPTION
## What is the purpose of the change

Replace all usages of the deprecated `CatalogTable.of(schema, comment, partitionKeys, options)` with the new builder API `CatalogTable.newBuilder().schema(s).comment(c).partitionKeys(p).options(o).build()`.

`CatalogTable.of()` is deprecated and will be removed in Flink 2.0 GA.

*JIRA: [FLINK-39657](https://issues.apache.org/jira/browse/FLINK-39657)*

## Brief change log

- Migrate all 43 call sites across 15 files (main source + tests)
- No behavioral changes — pure API migration

## Verifying this change

CI passed on fork: https://github.com/jlalwani-amazon/flink-connector-hive/actions

```bash
mvn compile test-compile -pl flink-connector-hive -am
```

## Does this pull request potentially affect one of the following parts?

- Dependencies: **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
