### PR TITLE
[FLINK-40023] HiveCatalog throws TableNotPartitionedException on partitioned non-hive table

### DIFF
--- a/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -64,6 +64,8 @@ import org.apache.hadoop.hive.ql.io.StorageFormatFactory;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -97,6 +99,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Utils to for Hive-backed table. */
 public class HiveTableUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HiveTableUtil.class);
 
     private static final byte HIVE_CONSTRAINT_ENABLE = 1 << 2;
     private static final byte HIVE_CONSTRAINT_VALIDATE = 1 << 1;
@@ -506,29 +510,6 @@ public class HiveTableUtil {
         // because hive cannot understand the expanded query anyway
         if (isHiveTable && !isView) {
             HiveTableUtil.initiateTableFromProperties(hiveTable, properties, hiveConf);
-            List<FieldSchema> allColumns =
-                    HiveTableUtil.createHiveColumns(table.getResolvedSchema());
-            // Table columns and partition keys
-            if (table instanceof CatalogTable) {
-                CatalogTable catalogTable = (CatalogTable) table;
-
-                if (catalogTable.isPartitioned()) {
-                    int partitionKeySize = catalogTable.getPartitionKeys().size();
-                    List<FieldSchema> regularColumns =
-                            allColumns.subList(0, allColumns.size() - partitionKeySize);
-                    List<FieldSchema> partitionColumns =
-                            allColumns.subList(
-                                    allColumns.size() - partitionKeySize, allColumns.size());
-
-                    sd.setCols(regularColumns);
-                    hiveTable.setPartitionKeys(partitionColumns);
-                } else {
-                    sd.setCols(allColumns);
-                    hiveTable.setPartitionKeys(new ArrayList<>());
-                }
-            } else {
-                sd.setCols(allColumns);
-            }
             // Table properties
             hiveTable.getParameters().putAll(properties);
         } else {
@@ -551,6 +532,47 @@ public class HiveTableUtil {
                 properties.put(IS_GENERIC, "true");
             }
             hiveTable.setParameters(properties);
+        }
+
+        List<FieldSchema> allColumns = null;
+        try {
+            allColumns =
+                    HiveTableUtil.createHiveColumns(table.getResolvedSchema());
+        } catch (Exception e) {
+            if (isHiveTable && !isView) {
+                // it's not ok if the Hive schema was not created from Flink schema for hive table.
+                // The exception should be thrown.
+                throw e;
+            } else {
+                // it's ok if we get the exception during converting Flink schema to Hive schema
+                // for non-hive tables because not all Flink types might be directly converted to
+                // Hive types.
+                LOG.warn("Can't convert Flink schema to Hive schema. The error message: '{}'", e.getMessage());
+            }
+        }
+
+        if (allColumns != null) {
+            // Table columns and partition keys
+            if (table instanceof CatalogTable) {
+                CatalogTable catalogTable = (CatalogTable) table;
+
+                if (catalogTable.isPartitioned()) {
+                    int partitionKeySize = catalogTable.getPartitionKeys().size();
+                    List<FieldSchema> regularColumns =
+                            allColumns.subList(0, allColumns.size() - partitionKeySize);
+                    List<FieldSchema> partitionColumns =
+                            allColumns.subList(
+                                    allColumns.size() - partitionKeySize, allColumns.size());
+
+                    sd.setCols(regularColumns);
+                    hiveTable.setPartitionKeys(partitionColumns);
+                } else {
+                    sd.setCols(allColumns);
+                    hiveTable.setPartitionKeys(new ArrayList<>());
+                }
+            } else {
+                sd.setCols(allColumns);
+            }
         }
 
         if (isView) {

--- a/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -269,6 +270,34 @@ public class HiveCatalogITCase {
                 "2019-12-12 00:00:05.0,2019-12-12 00:00:04.004001,3,50.00\n"
                         + "2019-12-12 00:00:10.0,2019-12-12 00:00:06.006001,2,5.33\n";
         assertThat(FileUtils.readFileUtf8(new File(new URI(sinkPath)))).isEqualTo(expected);
+    }
+
+    @Test
+    public void testShowPartitionsOnNonHiveTable() throws Exception {
+        TableEnvironment tableEnvStream =
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        tableEnvStream.getConfig().set(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+
+        tableEnvStream.registerCatalog("myhive", hiveCatalog);
+        tableEnvStream.useCatalog("myhive");
+
+        String sinkPath = new File(tempFolder.newFolder(), "sink").toURI().toString();
+
+        tableEnvStream.executeSql(
+                "create table test_table(\n"
+                        + "uuid varchar(20),\n"
+                        + "name varchar(10),\n"
+                        + "dt varchar(20)\n"
+                        + ")\n"
+                        + "PARTITIONED BY (dt) "
+                        + String.format(
+                        "WITH ('connector' = 'filesystem','path' = '%s','format' = 'csv')",
+                        sinkPath));
+
+        TableResult tableResult = tableEnvStream.executeSql("SHOW PARTITIONS test_table");
+        List<Row> result = CollectionUtil.iteratorToList(tableResult.collect());
+
+        assertThat(result).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Description
If we try to store the non-hive partitioned table (e.g. 'connector'='filesystem') using HiveCatalog, then the table metadata is stored inside hive metastore without information about partition keys. If we will try to invoke operation that requires partitioned table we get TableNotPartitionedException.

How to reproduce:
```sql
CREATE CATALOG myhive
WITH (
'type' = 'hive',
'hive-conf-dir' = '/opt/client/Hive/config',
'hive-version' = '3.1.0'
);

USE CATALOG myhive;

create table test_table(
uuid varchar(20),
name varchar(10),
dt varchar(20)
)
PARTITIONED BY (dt)
with (
'connector' = 'filesystem',
'path' = 'hdfs://hacluster/tmp/test_table',
'format'= 'csv'
);

SHOW PARTITIONS test_table;
```
It produces
```
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.table.catalog.exceptions.TableNotPartitionedException: Table default.test_table in catalog myhive is not partitioned.
```
 

SHOW PARTITIONS should not throw TableNotPartitionedException for a table created with PARTITIONED BY. If no partition instances are registered in the catalog, returning an empty result would be acceptable. Moreover, default catalog will also return an empty result for filesystem connector. So should HiveCatalog.

## Summary
Now partitions stored in underlying HiveTable for non-hive tables. Also added test to verify it works as default catalog.