### PR TITLE
[FLINK-40458][hive] Shade commons-lang dependencies

### DIFF
--- a/flink-sql-connector-hive-2.3.10/pom.xml
+++ b/flink-sql-connector-hive-2.3.10/pom.xml
@@ -155,6 +155,14 @@ under the License.
 									<pattern>com.google</pattern>
 									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.lang</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.commons.lang</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.lang3</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.commons.lang3</shadedPattern>
+								</relocation>
 							</relocations>
 							<!-- Table planner also contains calcite dependency. Exclude to prevent class conflicts. -->
 							<filters>

--- a/flink-sql-connector-hive-3.1.3/pom.xml
+++ b/flink-sql-connector-hive-3.1.3/pom.xml
@@ -311,6 +311,14 @@ under the License.
 									<pattern>com.google</pattern>
 									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.lang</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.commons.lang</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons.lang3</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.org.apache.commons.lang3</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

The `hive-exec` fat JAR bundles `commons-lang` and `commons-lang3` classes under their original package names. These classes can conflict with versions provided by Flink, other connectors, or user applications when the Hive SQL connector is placed on the classpath.

This change relocates both packages in the Hive 2.3.10 and Hive 3.1.3 SQL connector JARs:

- `org.apache.commons.lang`
- `org.apache.commons.lang3`

## Brief change log

- Add Commons Lang 2.x relocation to both Hive SQL connector Shade configurations.
- Add Commons Lang 3.x relocation to both Hive SQL connector Shade configurations.

## Verifying this change

- Ran `mvn -pl flink-sql-connector-hive-2.3.10,flink-sql-connector-hive-3.1.3 -am package` with the Java 17 module opens required by the existing Hive tests. All 397 unit tests passed, with 2 skipped.
- Inspected both generated connector JARs and confirmed that no classes remain under `org/apache/commons/lang/**` or `org/apache/commons/lang3/**`.
- Confirmed that the relocated classes and bytecode references use `org/apache/flink/hive/shaded/org/apache/commons/lang*`.

## Documentation

No documentation changes are required because this is an internal dependency isolation change.

Jira: https://issues.apache.org/jira/browse/FLINK-40458
